### PR TITLE
feat: adicionar tratamento inteligente de erros Evolution #26

### DIFF
--- a/app/services/evolution/error_handler.rb
+++ b/app/services/evolution/error_handler.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Evolution
+  class ErrorHandler
+    PHONE_NOT_FOUND_PATTERNS = [
+      /phone.*not.*exist/i,
+      /number.*not.*found/i,
+      /invalid.*number/i,
+      /numero.*não.*existe/i,
+      /telefone.*invalido/i,
+      /not.*registered/i,
+      /participant.*not.*found/i
+    ].freeze
+
+    CONNECTION_ERROR_PATTERNS = [
+      /connection.*refused/i,
+      /timeout/i,
+      /network.*error/i,
+      /unable.*to.*connect/i,
+      /socket.*error/i,
+      /offline/i
+    ].freeze
+
+    MEDIA_ERROR_PATTERNS = [
+      /media.*too.*large/i,
+      /file.*size.*exceeded/i,
+      /invalid.*media/i,
+      /unsupported.*format/i,
+      /arquivo.*muito.*grande/i
+    ].freeze
+
+    class << self
+      def handle_send_error(error)
+        error_message = extract_error_message(error)
+        error_type = classify_error(error_message)
+
+        {
+          user_message: user_friendly_message(error_type),
+          error_type: error_type,
+          technical_message: error_message
+        }
+      end
+
+      private
+
+      def extract_error_message(error)
+        return error.message if error.respond_to?(:message)
+        return error.to_s if error.is_a?(String)
+
+        'Unknown error'
+      end
+
+      def classify_error(message)
+        return :phone_not_found if matches_patterns?(message, PHONE_NOT_FOUND_PATTERNS)
+        return :connection_error if matches_patterns?(message, CONNECTION_ERROR_PATTERNS)
+        return :media_error if matches_patterns?(message, MEDIA_ERROR_PATTERNS)
+
+        :generic_error
+      end
+
+      def matches_patterns?(message, patterns)
+        patterns.any? { |pattern| pattern.match?(message) }
+      end
+
+      def user_friendly_message(error_type)
+        case error_type
+        when :phone_not_found
+          I18n.t('errors.evolution.phone_not_found',
+                 default: 'Erro ao enviar mensagem. Este número pode não existir no WhatsApp.')
+        when :connection_error
+          I18n.t('errors.evolution.connection_error',
+                 default: 'Erro de conexão. Verifique sua conexão e tente novamente.')
+        when :media_error
+          I18n.t('errors.evolution.media_error',
+                 default: 'Erro ao enviar arquivo. Verifique o tamanho e formato do arquivo.')
+        else
+          I18n.t('errors.evolution.generic',
+                 default: 'Erro ao enviar mensagem. Tente novamente.')
+        end
+      end
+    end
+  end
+end

--- a/app/services/evolution/send_message_service.rb
+++ b/app/services/evolution/send_message_service.rb
@@ -376,9 +376,21 @@ class Evolution::SendMessageService
   end
 
   def record_send_error!(error:, kind:, payload: {})
-    Rails.logger.error "[Evolution::SendMessageService] send_#{kind} error: #{error.class}: #{error.message}"
+    error_details = Evolution::ErrorHandler.handle_send_error(error)
 
-    update_message_status!(message: @message, status: 'failed', external_error: error.message)
+    Rails.logger.error(
+      "[Evolution::SendMessageService] send_#{kind} error: " \
+      "type=#{error_details[:error_type]} " \
+      "user_msg='#{error_details[:user_message]}' " \
+      "technical='#{error_details[:technical_message]}' " \
+      "payload=#{payload.inspect}"
+    )
+
+    update_message_status!(
+      message: @message,
+      status: 'failed',
+      external_error: error_details[:user_message]
+    )
   end
 
   def try_compress_video(attachment)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,6 +492,11 @@ en:
       invalid_token: Invalid or expired MFA token
       invalid_credentials: Invalid credentials or verification code
       feature_unavailable: MFA feature is not available. Please configure encryption keys.
+    evolution:
+      phone_not_found: Error sending message. This number may not exist on WhatsApp.
+      connection_error: Connection error. Check your connection and try again.
+      media_error: Error sending file. Please check the file size and format.
+      generic: Error sending message. Please try again.
   profile:
     mfa:
       enabled: MFA enabled successfully

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -88,6 +88,11 @@ pt_BR:
       invalid_token: Token MFA inválido ou expirado
       invalid_credentials: Credenciais ou código de verificação inválidos
       feature_unavailable: O recurso MFA não está disponível. Por favor, configure as chaves de criptografia.
+    evolution:
+      phone_not_found: Erro ao enviar mensagem. Este número pode não existir no WhatsApp.
+      connection_error: Erro de conexão. Verifique sua conexão e tente novamente.
+      media_error: Erro ao enviar arquivo. Verifique o tamanho e formato do arquivo.
+      generic: Erro ao enviar mensagem. Tente novamente.
   profile:
     mfa:
       enabled: MFA habilitado com sucesso

--- a/spec/services/evolution/error_handler_spec.rb
+++ b/spec/services/evolution/error_handler_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Evolution::ErrorHandler do
+  describe '.handle_send_error' do
+    context 'when phone number not found' do
+      it 'returns phone not found error for "phone not exist"' do
+        error = StandardError.new('phone not exist')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:phone_not_found)
+        expect(result[:user_message]).to include('número pode não existir')
+      end
+
+      it 'returns phone not found error for "participant not found"' do
+        error = StandardError.new('participant not found')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:phone_not_found)
+      end
+
+      it 'returns phone not found error for Portuguese message' do
+        error = StandardError.new('numero não existe no WhatsApp')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:phone_not_found)
+      end
+    end
+
+    context 'when connection error occurs' do
+      it 'returns connection error for timeout' do
+        error = StandardError.new('Request timeout')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:connection_error)
+        expect(result[:user_message]).to include('conexão')
+      end
+
+      it 'returns connection error for "connection refused"' do
+        error = StandardError.new('Connection refused')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:connection_error)
+      end
+    end
+
+    context 'when media error occurs' do
+      it 'returns media error for "media too large"' do
+        error = StandardError.new('Media file too large')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:media_error)
+        expect(result[:user_message]).to include('arquivo')
+      end
+
+      it 'returns media error for unsupported format' do
+        error = StandardError.new('Unsupported media format')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:media_error)
+      end
+    end
+
+    context 'when generic error occurs' do
+      it 'returns generic error type' do
+        error = StandardError.new('Random error message')
+        result = described_class.handle_send_error(error)
+
+        expect(result[:error_type]).to eq(:generic_error)
+        expect(result[:user_message]).to include('Erro ao enviar mensagem')
+      end
+    end
+
+    context 'when error is a string' do
+      it 'handles string errors' do
+        result = described_class.handle_send_error('phone not exist')
+
+        expect(result[:error_type]).to eq(:phone_not_found)
+        expect(result[:technical_message]).to eq('phone not exist')
+      end
+    end
+
+    it 'includes technical message for debugging' do
+      error = StandardError.new('Detailed error info')
+      result = described_class.handle_send_error(error)
+
+      expect(result[:technical_message]).to eq('Detailed error info')
+    end
+  end
+end


### PR DESCRIPTION
- Criado Evolution::ErrorHandler para centralizar tratamento de erros
- Classificação automática de erros (número inexistente, conexão, mídia, genérico)
- Mensagens amigáveis ao usuário em PT-BR e EN
- Integrado no SendMessageService para melhor feedback ao frontend
- Adicionados testes completos para todas as categorias de erro
- Logs aprimorados com tipo de erro e contexto técnico

# feat: Adicionar tratamento inteligente de erros Evolution #26

## 🎯 Objetivo

Melhorar o tratamento de erros do canal Evolution para fornecer feedback claro e útil ao usuário quando o envio de mensagens falha, especialmente quando o número de WhatsApp não existe.

## 🔍 Problema

Anteriormente, quando ocorria um erro no envio de mensagens via Evolution (ex: número inexistente no WhatsApp), o sistema retornava mensagens técnicas e genéricas que não ajudavam o usuário a entender o problema real.

## ✅ Solução Implementada

### 1. **Evolution::ErrorHandler** (Novo)
- Classe centralizada para classificação e tratamento de erros
- Detecta automaticamente 4 tipos de erro:
  - **Número inexistente**: `phone_not_found`
  - **Erro de conexão**: `connection_error` (timeout, network)
  - **Erro de mídia**: `media_error` (arquivo grande, formato inválido)
  - **Erro genérico**: `generic_error`

### 2. **Mensagens Amigáveis**
Adicionadas traduções em PT-BR e EN para cada tipo de erro:

**Português:**
- ✉️ "Erro ao enviar mensagem. Este número pode não existir no WhatsApp."
- 🔌 "Erro de conexão. Verifique sua conexão e tente novamente."
- 📎 "Erro ao enviar arquivo. Verifique o tamanho e formato do arquivo."
- ⚠️ "Erro ao enviar mensagem. Tente novamente."

**Inglês:**
- ✉️ "Error sending message. This number may not exist on WhatsApp."
- 🔌 "Connection error. Check your connection and try again."
- 📎 "Error sending file. Please check the file size and format."
- ⚠️ "Error sending message. Please try again."

### 3. **Integração com SendMessageService**
- Método [record_send_error!](cci:1://file:///home/matheus/starchat_app-1/app/services/evolution/send_message_service.rb:377:2-393:5) refatorado para usar [ErrorHandler](cci:2://file:///home/matheus/starchat_app-1/app/services/evolution/error_handler.rb:3:2-81:5)
- Logs aprimorados com tipo de erro, mensagem para o usuário e detalhes técnicos
- Frontend recebe mensagens claras através do campo `external_error`

### 4. **Testes Completos**
Criado [spec/services/evolution/error_handler_spec.rb](cci:7://file:///home/matheus/starchat_app-1/spec/services/evolution/error_handler_spec.rb:0:0-0:0) com cobertura para:
- Detecção de números inexistentes (múltiplos padrões)
- Erros de conexão e timeout
- Erros de mídia e formato
- Erros genéricos e edge cases

## 📁 Arquivos Modificados

**Novos:**
- [app/services/evolution/error_handler.rb](cci:7://file:///home/matheus/starchat_app-1/app/services/evolution/error_handler.rb:0:0-0:0)
- [spec/services/evolution/error_handler_spec.rb](cci:7://file:///home/matheus/starchat_app-1/spec/services/evolution/error_handler_spec.rb:0:0-0:0)

**Modificados:**
- [app/services/evolution/send_message_service.rb](cci:7://file:///home/matheus/starchat_app-1/app/services/evolution/send_message_service.rb:0:0-0:0)
- [config/locales/pt_BR.yml](cci:7://file:///home/matheus/starchat_app-1/config/locales/pt_BR.yml:0:0-0:0)
- [config/locales/en.yml](cci:7://file:///home/matheus/starchat_app-1/config/locales/en.yml:0:0-0:0)

## 🧪 Como Testar

1. **Cenário 1: Número inexistente**