### PR TITLE
feat: Add contact filter by inbox, immutable inbox associations and t…

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -17,6 +17,8 @@ class ContactInboxBuilder
       twilio_source_id
     when 'Channel::Whatsapp'
       wa_source_id
+    when 'Channel::Evolution'
+      evolution_source_id
     when 'Channel::Email'
       email_source_id
     when 'Channel::Sms'
@@ -44,6 +46,12 @@ class ContactInboxBuilder
     raise ActionController::ParameterMissing, 'contact phone number' unless @contact.phone_number
 
     # whatsapp doesn't want the + in e164 format
+    @contact.phone_number.delete('+').to_s
+  end
+
+  def evolution_source_id
+    raise ActionController::ParameterMissing, 'contact phone number' unless @contact.phone_number
+
     @contact.phone_number.delete('+').to_s
   end
 

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -59,8 +59,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     @contacts_count = @contacts.total_count
   end
 
-  def show
-  end
+  def show; end
 
   def filter
     result = ::Contacts::FilterService.new(Current.account, Current.user, params.permit!).perform

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -59,7 +59,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     @contacts_count = @contacts.total_count
   end
 
-  def show; end
+  def show
+  end
 
   def filter
     result = ::Contacts::FilterService.new(Current.account, Current.user, params.permit!).perform
@@ -96,7 +97,13 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   def update
     @contact.assign_attributes(contact_update_params)
     @contact.save!
+    if params[:inbox_ids].is_a?(Array)
+      add_new_contact_inboxes(params[:inbox_ids])
+    else
+      build_contact_inbox
+    end
     process_avatar_from_url
+    @contact.reload
   end
 
   def destroy
@@ -117,6 +124,22 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   private
+
+  # Only adds new inboxes. Existing associations are immutable through this endpoint
+  # to prevent accidental removal of conversation history.
+  def add_new_contact_inboxes(inbox_ids)
+    target_ids = inbox_ids.map(&:to_i).uniq
+    existing_inbox_ids = @contact.contact_inboxes.pluck(:inbox_id)
+    new_inbox_ids = target_ids - existing_inbox_ids
+
+    return if new_inbox_ids.empty?
+
+    Current.account.inboxes.where(id: new_inbox_ids).find_each do |inbox|
+      ContactInboxBuilder.new(contact: @contact, inbox: inbox).perform
+    rescue StandardError => e
+      Rails.logger.error "Failed to create contact inbox: #{e.message}"
+    end
+  end
 
   # TODO: Move this to a finder class
   def resolved_contacts

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -55,9 +55,7 @@ module Filters::FilterHelper
 
   def handle_standard_attributes(current_filter, query_hash, current_index, filter_operator_value)
     # Para contatos, inbox_id é uma relação many-to-many através de contact_inboxes
-    if query_hash[:attribute_key] == 'inbox_id' && filter_config[:entity] == 'Contact'
-      return contact_inbox_filter_query(query_hash, current_index)
-    end
+    return contact_inbox_filter_query(query_hash, current_index) if query_hash[:attribute_key] == 'inbox_id' && filter_config[:entity] == 'Contact'
 
     case current_filter['data_type']
     when 'date'
@@ -109,12 +107,12 @@ module Filters::FilterHelper
 
   def contact_inbox_filter_query(query_hash, current_index)
     query_operator = query_hash[:query_operator]
+    # rubocop:disable Rails/HelperInstanceVariable
     @filter_values["value_#{current_index}"] = filter_values(query_hash)
+    # rubocop:enable Rails/HelperInstanceVariable
 
-    contact_inbox_relation_query = 
-      "SELECT * FROM contact_inboxes WHERE contact_inboxes.contact_id = contacts.id"
-    inbox_query = 
-      "AND contact_inboxes.inbox_id IN (:value_#{current_index})"
+    contact_inbox_relation_query = 'SELECT * FROM contact_inboxes WHERE contact_inboxes.contact_id = contacts.id'
+    inbox_query = "AND contact_inboxes.inbox_id IN (:value_#{current_index})"
 
     case query_hash[:filter_operator]
     when 'equal_to'

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -54,6 +54,11 @@ module Filters::FilterHelper
   end
 
   def handle_standard_attributes(current_filter, query_hash, current_index, filter_operator_value)
+    # Para contatos, inbox_id é uma relação many-to-many através de contact_inboxes
+    if query_hash[:attribute_key] == 'inbox_id' && filter_config[:entity] == 'Contact'
+      return contact_inbox_filter_query(query_hash, current_index)
+    end
+
     case current_filter['data_type']
     when 'date'
       date_filter(current_filter, query_hash, filter_operator_value)
@@ -100,5 +105,26 @@ module Filters::FilterHelper
 
   def message_type_values(values)
     values.map { |x| Message.message_types[x.to_sym] }
+  end
+
+  def contact_inbox_filter_query(query_hash, current_index)
+    query_operator = query_hash[:query_operator]
+    @filter_values["value_#{current_index}"] = filter_values(query_hash)
+
+    contact_inbox_relation_query = 
+      "SELECT * FROM contact_inboxes WHERE contact_inboxes.contact_id = contacts.id"
+    inbox_query = 
+      "AND contact_inboxes.inbox_id IN (:value_#{current_index})"
+
+    case query_hash[:filter_operator]
+    when 'equal_to'
+      "EXISTS (#{contact_inbox_relation_query} #{inbox_query}) #{query_operator}"
+    when 'not_equal_to'
+      "NOT EXISTS (#{contact_inbox_relation_query} #{inbox_query}) #{query_operator}"
+    when 'is_present'
+      "EXISTS (#{contact_inbox_relation_query}) #{query_operator}"
+    when 'is_not_present'
+      "NOT EXISTS (#{contact_inbox_relation_query}) #{query_operator}"
+    end
   end
 end

--- a/app/javascript/dashboard/api/contacts.js
+++ b/app/javascript/dashboard/api/contacts.js
@@ -2,7 +2,7 @@
 import ApiClient from './ApiClient';
 
 export const buildContactParams = (page, sortAttr, label, search) => {
-  let params = `include_contact_inboxes=false&page=${page}&sort=${sortAttr}`;
+  let params = `include_contact_inboxes=true&page=${page}&sort=${sortAttr}`;
   if (search) {
     params = `${params}&q=${search}`;
   }
@@ -28,11 +28,11 @@ class ContactAPI extends ApiClient {
   }
 
   show(id) {
-    return axios.get(`${this.url}/${id}?include_contact_inboxes=false`);
+    return axios.get(`${this.url}/${id}?include_contact_inboxes=true`);
   }
 
   update(id, data) {
-    return axios.patch(`${this.url}/${id}?include_contact_inboxes=false`, data);
+    return axios.patch(`${this.url}/${id}`, data);
   }
 
   getConversations(contactId) {

--- a/app/javascript/dashboard/api/specs/contacts.spec.js
+++ b/app/javascript/dashboard/api/specs/contacts.spec.js
@@ -34,7 +34,7 @@ describe('#ContactsAPI', () => {
     it('#get', () => {
       contactAPI.get(1, 'name', 'customer-support');
       expect(axiosMock.get).toHaveBeenCalledWith(
-        '/api/v1/contacts?include_contact_inboxes=false&page=1&sort=name&labels[]=customer-support'
+        '/api/v1/contacts?include_contact_inboxes=true&page=1&sort=name&labels[]=customer-support'
       );
     });
 
@@ -68,7 +68,7 @@ describe('#ContactsAPI', () => {
     it('#search', () => {
       contactAPI.search('leads', 1, 'date', 'customer-support');
       expect(axiosMock.get).toHaveBeenCalledWith(
-        '/api/v1/contacts/search?include_contact_inboxes=false&page=1&sort=date&q=leads&labels[]=customer-support'
+        '/api/v1/contacts/search?include_contact_inboxes=true&page=1&sort=date&q=leads&labels[]=customer-support'
       );
     });
 
@@ -107,7 +107,7 @@ describe('#ContactsAPI', () => {
       };
       contactAPI.filter(1, 'name', queryPayload);
       expect(axiosMock.post).toHaveBeenCalledWith(
-        '/api/v1/contacts/filter?include_contact_inboxes=false&page=1&sort=name',
+        '/api/v1/contacts/filter?include_contact_inboxes=true&page=1&sort=name',
         queryPayload
       );
     });
@@ -124,15 +124,15 @@ describe('#ContactsAPI', () => {
 describe('#buildContactParams', () => {
   it('returns correct string', () => {
     expect(buildContactParams(1, 'name', '', '')).toBe(
-      'include_contact_inboxes=false&page=1&sort=name'
+      'include_contact_inboxes=true&page=1&sort=name'
     );
     expect(buildContactParams(1, 'name', 'customer-support', '')).toBe(
-      'include_contact_inboxes=false&page=1&sort=name&labels[]=customer-support'
+      'include_contact_inboxes=true&page=1&sort=name&labels[]=customer-support'
     );
     expect(
       buildContactParams(1, 'name', 'customer-support', 'message-content')
     ).toBe(
-      'include_contact_inboxes=false&page=1&sort=name&q=message-content&labels[]=customer-support'
+      'include_contact_inboxes=true&page=1&sort=name&q=message-content&labels[]=customer-support'
     );
   });
 });

--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -24,6 +24,7 @@ const props = defineProps({
   isUpdating: { type: Boolean, default: false },
   selectable: { type: Boolean, default: false },
   isSelected: { type: Boolean, default: false },
+  contactInboxes: { type: Array, default: () => [] },
 });
 
 const emit = defineEmits([
@@ -44,6 +45,7 @@ const getInitialContactData = () => ({
   email: props.email,
   phoneNumber: props.phoneNumber,
   additionalAttributes: props.additionalAttributes,
+  contactInboxes: props.contactInboxes,
 });
 
 const contactData = ref(getInitialContactData());

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -113,7 +113,8 @@ const prepareStateBasedOnProps = () => {
     socialProfiles = {},
   } = additionalAttributes || {};
 
-  const inboxIds = contactInboxes.length > 0 ? contactInboxes.map(ci => ci.inbox.id) : [];
+  const inboxIds =
+    contactInboxes.length > 0 ? contactInboxes.map(ci => ci.inbox.id) : [];
   disabledInboxIds.value = inboxIds;
 
   Object.assign(state, {
@@ -289,7 +290,7 @@ defineExpose({
             v-model="state.inboxIds"
             :options="inboxOptions"
             :placeholder="item.placeholder"
-            :multiple="true"
+            multiple
             :disabled-values="disabledInboxIds"
             class="[&>div>button]:h-8"
             :class="{

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, reactive, watch } from 'vue';
+import { computed, reactive, watch, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { required, email } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
@@ -8,6 +8,8 @@ import countries from 'shared/constants/countries.js';
 import Input from 'dashboard/components-next/input/Input.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
+import { useMapGetter } from 'dashboard/composables/store';
+import { useChannelIcon } from 'next/icon/provider';
 import PhoneNumberInput from 'dashboard/components-next/phonenumberinput/PhoneNumberInput.vue';
 
 const props = defineProps({
@@ -28,6 +30,7 @@ const props = defineProps({
 const emit = defineEmits(['update']);
 
 const { t } = useI18n();
+const inboxes = useMapGetter('inboxes/getInboxes');
 
 const FORM_CONFIG = {
   FIRST_NAME: { field: 'firstName' },
@@ -38,6 +41,7 @@ const FORM_CONFIG = {
   COUNTRY: { field: 'additionalAttributes.countryCode' },
   BIO: { field: 'additionalAttributes.description' },
   COMPANY_NAME: { field: 'additionalAttributes.companyName' },
+  INBOX: { field: 'inboxIds' },
 };
 
 const SOCIAL_CONFIG = {
@@ -55,6 +59,7 @@ const defaultState = {
   firstName: '',
   lastName: '',
   phoneNumber: '',
+  inboxIds: [],
   additionalAttributes: {
     description: '',
     companyName: '',
@@ -72,6 +77,7 @@ const defaultState = {
 };
 
 const state = reactive({ ...defaultState });
+const disabledInboxIds = ref([]);
 
 const validationRules = {
   firstName: { required },
@@ -93,7 +99,10 @@ const prepareStateBasedOnProps = () => {
     email: emailAddress,
     phoneNumber,
     additionalAttributes = {},
+    contact_inboxes: contactInboxesSnake,
+    contactInboxes: contactInboxesCamel,
   } = props.contactData || {};
+  const contactInboxes = contactInboxesCamel || contactInboxesSnake || [];
   const { firstName, lastName } = splitName(name || '');
   const {
     description = '',
@@ -104,6 +113,9 @@ const prepareStateBasedOnProps = () => {
     socialProfiles = {},
   } = additionalAttributes || {};
 
+  const inboxIds = contactInboxes.length > 0 ? contactInboxes.map(ci => ci.inbox.id) : [];
+  disabledInboxIds.value = inboxIds;
+
   Object.assign(state, {
     id,
     name,
@@ -111,6 +123,7 @@ const prepareStateBasedOnProps = () => {
     lastName,
     email: emailAddress,
     phoneNumber,
+    inboxIds,
     additionalAttributes: {
       description,
       companyName,
@@ -124,6 +137,14 @@ const prepareStateBasedOnProps = () => {
 
 const countryOptions = computed(() =>
   countries.map(({ name, id }) => ({ label: name, value: id }))
+);
+
+const inboxOptions = computed(() =>
+  inboxes.value.map(inbox => ({
+    label: inbox.name,
+    value: inbox.id,
+    icon: useChannelIcon(inbox).value,
+  }))
 );
 
 const editDetailsForm = computed(() =>
@@ -210,6 +231,11 @@ const handleCountrySelection = value => {
   emit('update', state);
 };
 
+const handleInboxChange = () => {
+  const { firstName, lastName, ...stateWithoutNames } = state;
+  emit('update', stateWithoutNames);
+};
+
 const resetValidation = () => {
   v$.value.$reset();
 };
@@ -219,9 +245,11 @@ const resetForm = () => {
 };
 
 watch(
-  () => props.contactData?.id,
-  id => {
-    if (id) prepareStateBasedOnProps();
+  () => [props.contactData?.id, props.contactData?.contactInboxes?.length],
+  () => {
+    if (props.contactData?.id && !props.isNewContact) {
+      prepareStateBasedOnProps();
+    }
   },
   { immediate: true }
 );
@@ -255,6 +283,21 @@ defineExpose({
               '[&>div>button]:!bg-n-alpha-black2': isDetailsView,
             }"
             @update:model-value="handleCountrySelection"
+          />
+          <ComboBox
+            v-else-if="item.key === 'INBOX'"
+            v-model="state.inboxIds"
+            :options="inboxOptions"
+            :placeholder="item.placeholder"
+            :multiple="true"
+            :disabled-values="disabledInboxIds"
+            class="[&>div>button]:h-8"
+            :class="{
+              '[&>div>button]:bg-n-alpha-black2 [&>div>button:not(.focused)]:!outline-transparent':
+                !isDetailsView,
+              '[&>div>button]:!bg-n-alpha-black2': isDetailsView,
+            }"
+            @update:model-value="handleInboxChange"
           />
           <PhoneNumberInput
             v-else-if="item.key === 'PHONE_NUMBER'"

--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
@@ -97,6 +97,7 @@ const handleAvatarHover = (id, isHovered) => {
         :additional-attributes="contact.additionalAttributes"
         :custom-attributes="contact.customAttributes"
         :availability-status="contact.availabilityStatus"
+        :contact-inboxes="contact.contactInboxes"
         :is-expanded="expandedCardId === contact.id"
         :is-updating="isUpdating"
         :selectable="shouldShowSelection(contact.id)"

--- a/app/javascript/dashboard/components-next/combobox/ComboBox.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBox.vue
@@ -14,13 +14,15 @@ const props = defineProps({
       value.every(option => 'value' in option && 'label' in option),
   },
   placeholder: { type: String, default: '' },
-  modelValue: { type: [String, Number], default: '' },
+  modelValue: { type: [String, Number, Array], default: '' },
   disabled: { type: Boolean, default: false },
   searchPlaceholder: { type: String, default: '' },
   emptyState: { type: String, default: '' },
   message: { type: String, default: '' },
   hasError: { type: Boolean, default: false },
   useApiResults: { type: Boolean, default: false }, // useApiResults prop to determine if search is handled by API
+  multiple: { type: Boolean, default: false },
+  disabledValues: { type: Array, default: () => [] },
 });
 
 const emit = defineEmits(['update:modelValue', 'search']);
@@ -49,6 +51,13 @@ const selectPlaceholder = computed(() => {
   return props.placeholder || t('COMBOBOX.PLACEHOLDER');
 });
 const selectedLabel = computed(() => {
+  if (props.multiple && Array.isArray(selectedValue.value)) {
+    if (selectedValue.value.length === 0) return selectPlaceholder.value;
+    const labels = props.options
+      .filter(option => selectedValue.value.includes(option.value))
+      .map(option => option.label);
+    return labels.join(', ');
+  }
   const selected = props.options.find(
     option => option.value === selectedValue.value
   );
@@ -56,10 +65,23 @@ const selectedLabel = computed(() => {
 });
 
 const selectOption = option => {
-  selectedValue.value = option.value;
-  emit('update:modelValue', option.value);
-  open.value = false;
-  search.value = '';
+  if (props.multiple) {
+    let newVal;
+    const current = Array.isArray(selectedValue.value) ? selectedValue.value : [];
+    if (current.includes(option.value)) {
+      if (props.disabledValues.includes(option.value)) return;
+      newVal = current.filter(v => v !== option.value);
+    } else {
+      newVal = [...current, option.value];
+    }
+    selectedValue.value = newVal;
+    emit('update:modelValue', newVal);
+  } else {
+    selectedValue.value = option.value;
+    emit('update:modelValue', option.value);
+    open.value = false;
+    search.value = '';
+  }
 };
 
 const toggleDropdown = () => {
@@ -115,6 +137,8 @@ watch(
         :search-placeholder="searchPlaceholder"
         :empty-state="emptyState"
         :selected-values="selectedValue"
+        :multiple="multiple"
+        :disabled-values="disabledValues"
         @search="emit('search', $event)"
         @select="selectOption"
       />

--- a/app/javascript/dashboard/components-next/combobox/ComboBox.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBox.vue
@@ -67,7 +67,9 @@ const selectedLabel = computed(() => {
 const selectOption = option => {
   if (props.multiple) {
     let newVal;
-    const current = Array.isArray(selectedValue.value) ? selectedValue.value : [];
+    const current = Array.isArray(selectedValue.value)
+      ? selectedValue.value
+      : [];
     if (current.includes(option.value)) {
       if (props.disabledValues.includes(option.value)) return;
       newVal = current.filter(v => v !== option.value);

--- a/app/javascript/dashboard/components-next/combobox/ComboBoxDropdown.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBoxDropdown.vue
@@ -27,6 +27,10 @@ const props = defineProps({
     type: [String, Number, Array],
     default: () => [],
   },
+  disabledValues: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits(['select', 'search']);
@@ -81,10 +85,13 @@ defineExpose({
       <li
         v-for="option in options"
         :key="option.value"
-        class="flex items-center justify-between w-full gap-2 px-3 py-2 text-sm transition-colors duration-150 cursor-pointer hover:bg-n-alpha-2"
+        class="flex items-center justify-between w-full gap-2 px-3 py-2 text-sm transition-colors duration-150"
         :class="{
           'bg-n-alpha-2': isSelected(option),
+          'opacity-50 cursor-not-allowed': disabledValues.includes(option.value),
+          'cursor-pointer hover:bg-n-alpha-2': !disabledValues.includes(option.value),
         }"
+
         role="option"
         :aria-selected="isSelected(option)"
         @click="emit('select', option)"

--- a/app/javascript/dashboard/components-next/combobox/ComboBoxDropdown.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBoxDropdown.vue
@@ -88,10 +88,13 @@ defineExpose({
         class="flex items-center justify-between w-full gap-2 px-3 py-2 text-sm transition-colors duration-150"
         :class="{
           'bg-n-alpha-2': isSelected(option),
-          'opacity-50 cursor-not-allowed': disabledValues.includes(option.value),
-          'cursor-pointer hover:bg-n-alpha-2': !disabledValues.includes(option.value),
+          'opacity-50 cursor-not-allowed': disabledValues.includes(
+            option.value
+          ),
+          'cursor-pointer hover:bg-n-alpha-2': !disabledValues.includes(
+            option.value
+          ),
         }"
-
         role="option"
         :aria-selected="isSelected(option)"
         @click="emit('select', option)"

--- a/app/javascript/dashboard/components-next/filter/contactProvider.js
+++ b/app/javascript/dashboard/components-next/filter/contactProvider.js
@@ -1,7 +1,8 @@
-import { computed } from 'vue';
+import { computed, h } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useOperators } from './operators';
 import { useMapGetter } from 'dashboard/composables/store.js';
+import { useChannelIcon } from 'next/icon/provider';
 import {
   buildAttributesFilterTypes,
   CONTACT_ATTRIBUTES,
@@ -51,10 +52,12 @@ export function useContactFilterContext() {
 
   const contactAttributes = useMapGetter('attributes/getContactAttributes');
   const labels = useMapGetter('labels/getLabels');
+  const inboxes = useMapGetter('inboxes/getInboxes');
 
   const {
     equalityOperators,
     containmentOperators,
+    presenceOperators,
     dateOperators,
     getOperatorTypes,
   } = useOperators();
@@ -133,6 +136,22 @@ export function useContactFilterContext() {
       inputType: 'plainText',
       dataType: 'text',
       filterOperators: containmentOperators.value,
+      attributeModel: 'standard',
+    },
+    {
+      attributeKey: CONTACT_ATTRIBUTES.INBOX_ID,
+      value: CONTACT_ATTRIBUTES.INBOX_ID,
+      attributeName: t('CONTACTS_LAYOUT.FILTER.INBOX'),
+      label: t('CONTACTS_LAYOUT.FILTER.INBOX'),
+      inputType: 'searchSelect',
+      options: inboxes.value.map(inbox => {
+        return {
+          ...inbox,
+          icon: useChannelIcon(inbox).value,
+        };
+      }),
+      dataType: 'text',
+      filterOperators: presenceOperators.value,
       attributeModel: 'standard',
     },
     {

--- a/app/javascript/dashboard/components-next/filter/helper/filterHelper.js
+++ b/app/javascript/dashboard/components-next/filter/helper/filterHelper.js
@@ -24,6 +24,7 @@ export const CONTACT_ATTRIBUTES = {
   IDENTIFIER: 'identifier',
   COUNTRY_CODE: 'country_code',
   CITY: 'city',
+  INBOX_ID: 'inbox_id',
   CREATED_AT: 'created_at',
   LAST_ACTIVITY_AT: 'last_activity_at',
   REFERER: 'referer',

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -385,6 +385,7 @@
       "IDENTIFIER": "Identifier",
       "COUNTRY": "Country",
       "CITY": "City",
+      "INBOX": "Inbox",
       "CREATED_AT": "Created at",
       "LAST_ACTIVITY": "Last activity",
       "REFERER_LINK": "Referer link",
@@ -439,6 +440,9 @@
           },
           "COMPANY_NAME": {
             "PLACEHOLDER": "Enter the company name"
+          },
+          "INBOX": {
+            "PLACEHOLDER": "Select inbox"
           }
         },
         "UPDATE_BUTTON": "Update contact",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/contact.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/contact.json
@@ -384,6 +384,7 @@
       "IDENTIFIER": "Identificador",
       "COUNTRY": "País/região",
       "CITY": "Cidade",
+      "INBOX": "Caixa de Entrada",
       "CREATED_AT": "Criado em",
       "LAST_ACTIVITY": "Última atividade",
       "REFERER_LINK": "Link de origem",
@@ -438,6 +439,9 @@
           },
           "COMPANY_NAME": {
             "PLACEHOLDER": "Digite o nome da empresa"
+          },
+          "INBOX": {
+            "PLACEHOLDER": "Selecione a caixa de entrada"
           }
         },
         "UPDATE_BUTTON": "Atualizar contato",

--- a/app/services/contacts/filter_service.rb
+++ b/app/services/contacts/filter_service.rb
@@ -24,6 +24,10 @@ class Contacts::FilterService < FilterService
       "+#{current_val&.delete('+')}"
     elsif query_hash['attribute_key'] == 'country_code'
       current_val.downcase
+    elsif query_hash['attribute_key'] == 'inbox_id'
+      # inbox_id em contatos é uma relação many-to-many através de contact_inboxes
+      # então retornamos os valores como estão (IDs dos inboxes)
+      query_hash['values']
     else
       current_val.is_a?(String) ? current_val.downcase : current_val
     end

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -3,7 +3,6 @@
 # 2. Contact Filters (app/services/filter_service.rb)
 # 3. Automation Filters  (app/services/automation_rules/conditions_filter_service.rb), (app/services/automation_rules/condition_validation_service.rb)
 
-
 # Format
 # - Parent Key (conversation, contact, messages)
 #   - Key (attribute_name)
@@ -15,218 +14,224 @@
 
 conversations:
   status:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   assignee_id:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   inbox_id:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   team_id:
-    attribute_type: "standard"
-    data_type: "number"
+    attribute_type: 'standard'
+    data_type: 'number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   priority:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   display_id:
-    attribute_type: "standard"
-    data_type: "Number"
+    attribute_type: 'standard'
+    data_type: 'Number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   campaign_id:
-    attribute_type: "standard"
-    data_type: "Number"
+    attribute_type: 'standard'
+    data_type: 'Number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   labels:
-    attribute_type: "standard"
-    data_type: "labels"
+    attribute_type: 'standard'
+    data_type: 'labels'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   browser_language:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   conversation_language:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   country_code:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   referer:
-    attribute_type: "additional_attributes"
-    data_type: "link"
+    attribute_type: 'additional_attributes'
+    data_type: 'link'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   created_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   last_activity_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   mail_subject:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
 
 ### ----- End of Conversation Filters ----- ###
-
 
 ### ----- Contact Filters ----- ###
 contacts:
   name:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   phone_number:
-    attribute_type: "standard"
-    data_type: "text" # Text is not explicity defined in filters, default filter will be used
+    attribute_type: 'standard'
+    data_type: 'text' # Text is not explicity defined in filters, default filter will be used
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
-      - "starts_with"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
+      - 'starts_with'
   email:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   identifier:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   country_code:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   city:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
+  inbox_id:
+    attribute_type: 'standard'
+    data_type: 'text'
+    filter_operators:
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   company:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   labels:
-    attribute_type: "standard"
-    data_type: "labels"
+    attribute_type: 'standard'
+    data_type: 'labels'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   created_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   last_activity_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   blocked:
-    attribute_type: "standard"
-    data_type: "boolean"
+    attribute_type: 'standard'
+    data_type: 'boolean'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
 
 ### ----- End of Contact Filters ----- ###
 
 ### ----- Message Filters ----- ###
 messages:
   message_type:
-    attribute_type: "standard"
-    data_type: "numeric"
+    attribute_type: 'standard'
+    data_type: 'numeric'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   content:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
-
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
 ### ----- End of Message Filters ----- ###

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -442,6 +442,25 @@ RSpec.describe 'Contacts API', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include('Invalid value. The values provided for country_code are invalid"')
       end
+
+      it 'filters by inbox_id' do
+        inbox = create(:inbox, account: account)
+        contact_in_inbox = create(:contact, :with_email, account: account)
+        create(:contact_inbox, contact: contact_in_inbox, inbox: inbox)
+        
+        post "/api/v1/accounts/#{account.id}/contacts/filter",
+             params: { payload: [
+               attribute_key: 'inbox_id',
+               filter_operator: 'equal_to',
+               values: [inbox.id]
+             ] },
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(contact_in_inbox.email)
+        expect(response.body).not_to include(contact1.email)
+      end
     end
   end
 
@@ -670,6 +689,33 @@ RSpec.describe 'Contacts API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(contact.reload.blocked).to be(false)
+      end
+
+      it 'adds new contact inboxes' do
+        inbox = create(:inbox, account: account)
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: valid_params.merge(inbox_ids: [inbox.id]),
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.inboxes).to include(inbox)
+      end
+
+      it 'does not remove existing contact inboxes (immutable)' do
+        existing_inbox = create(:inbox, account: account)
+        create(:contact_inbox, contact: contact, inbox: existing_inbox)
+        new_inbox = create(:inbox, account: account)
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: valid_params.merge(inbox_ids: [new_inbox.id]),
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        contact.reload
+        expect(contact.inboxes).to include(new_inbox)
+        expect(contact.inboxes).to include(existing_inbox)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe 'Contacts API', type: :request do
         inbox = create(:inbox, account: account)
         contact_in_inbox = create(:contact, :with_email, account: account)
         create(:contact_inbox, contact: contact_in_inbox, inbox: inbox)
-        
+
         post "/api/v1/accounts/#{account.id}/contacts/filter",
              params: { payload: [
                attribute_key: 'inbox_id',


### PR DESCRIPTION
📝 Descrição do PR
🎯 Objetivo
Implementar a funcionalidade de filtragem de contatos por caixa de entrada (Inbox) e garantir a imutabilidade das associações de caixas de entrada existentes na edição do contato, evitando a remoção acidental de histórico de conversas.

🛠 Alterações Realizadas
Backend

ContactsController ( app/controllers/api/v1/accounts/contacts_controller.rb ):

Refatoração do método update_contact_inboxes para 
add_new_contact_inboxes
 para refletir melhor o comportamento.
Imutabilidade: O endpoint agora apenas adiciona novas caixas de entrada. Associações existentes são preservadas e não podem ser removidas via atualização de contato.
Otimização: Lógica ajustada para evitar consultas N+1, buscando apenas as inboxes que ainda não estão associadas.
Adicionado reload no objeto @contact antes da resposta para garantir consistência dos dados retornados.

Filtros (app/services/contacts/filter_service.rb):

Adicionado suporte para filtragem por inbox_id (Equal to / Not Equal to).
Atualização dos arquivos de configuração e helpers de filtro (filter_keys.yml, filter_helper.rb, filterHelper.js).
Frontend

ContactsForm (ContactsForm.vue):

Implementada lógica para bloquear a remoção de Inboxes que já vieram salvas do banco de dados (propriedade disabledInboxIds).
Novos Inboxes adicionados na sessão atual ainda podem ser removidos antes de salvar.
Componente ComboBox:
Adicionada prop disabledValues para suportar itens imutáveis na seleção múltipla.
UI/UX: Itens desabilitados no dropdown agora aparecem com opacidade reduzida e cursor not-allowed, e a ação de desmarcar é bloqueada.
Testes

RSpec (spec/controllers/api/v1/accounts/contacts_controller_spec.rb):

✅ Teste adicionado para garantir que novos inboxes são vinculados corretamente.
✅ Teste de segurança adicionado para verificar se inboxes existentes não são removidos (imutabilidade).
✅ Teste de integração para o novo filtro por inbox_id.
🔍 Como Testar
Vá para a página de contatos e tente editar um contato existente.
Tente remover uma Inbox que já estava vinculada. Resultado Esperado: O item deve estar visualmente bloqueado e não permitir desmarcação.
Adicione uma nova Inbox e salve.
Utilize o filtro avançado de contatos, selecione "Inbox" e escolha uma caixa de entrada. Resultado Esperado: A lista deve exibir apenas os contatos vinculados àquela inbox.
