### PR TITLE
Fix/duplicate media handling

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-backend: bundle exec rails s -p 3002 -b 0.0.0.0
+backend: bundle exec rails s -p 3000 -b 0.0.0.0
 worker: bundle exec sidekiq -C config/sidekiq.yml
 vite: bin/vite dev

--- a/app/controllers/webhooks/evolution_controller.rb
+++ b/app/controllers/webhooks/evolution_controller.rb
@@ -18,7 +18,16 @@ class Webhooks::EvolutionController < ActionController::API
     handle_event(event, data)
 
     # Re-wrap data if necessary for the job
-    data = [data] if %w[messages_upsert messages_update contacts_update chats_update].include?(event) && data.is_a?(Hash)
+    if %w[messages_upsert messages_update contacts_update chats_update].include?(event)
+      data = [data] if data.is_a?(Hash)
+
+      # Deduplicate messages
+      if event == 'messages_upsert'
+        data = data.reject { |msg| message_already_processed?(msg) }
+        return head :ok if data.empty?
+      end
+    end
+
     Webhooks::EvolutionEventsJob.perform_later(inbox_id: @inbox.id, event: event, data: data || [])
 
     head :ok
@@ -109,5 +118,14 @@ class Webhooks::EvolutionController < ActionController::API
 
   def normalize_event(e)
     e.to_s.tr('.', '_').downcase
+  end
+
+  def message_already_processed?(msg_data)
+    unique_id = msg_data.dig('key', 'id')
+    return false if unique_id.blank?
+
+    # Returns true (processed) if Redis key already exists (set returns nil)
+    # Returns false (new) if Redis key was set successfully
+    !Redis::Alfred.set("evolution:dedup:#{@inbox.id}:#{unique_id}", 1, nx: true, ex: 3.minutes)
   end
 end

--- a/app/jobs/webhooks/evolution_events_job.rb
+++ b/app/jobs/webhooks/evolution_events_job.rb
@@ -8,6 +8,10 @@ class Webhooks::EvolutionEventsJob < ApplicationJob
     @inbox = Inbox.find_by(id: inbox_id)
     return unless @inbox&.channel.is_a?(Channel::Evolution)
 
+    # Set URL options for ActiveStorage URL generation in background jobs
+    base_url = ENV.fetch('FRONTEND_URL', 'http://localhost:3000').to_s.chomp('/')
+    ActiveStorage::Current.url_options = { host: base_url }
+
     evt  = event.to_s.tr('.', '_').downcase
     rows = Array.wrap(data).compact
     rows = rows.reject { |r| r.respond_to?(:empty?) && r.empty? }

--- a/app/services/evolution/client.rb
+++ b/app/services/evolution/client.rb
@@ -93,6 +93,10 @@ module Evolution
     # POST /message/sendText/:instance
     # body: { number:, text:, quoted?, delay?, mentionsEveryOne?, mentioned? }
     def send_text(instance, number:, text:, quoted: nil, delay: 0)
+      # Deduplication check
+      key_payload = { instance: instance, number: number, text: text }
+      return { 'success' => true, 'deduplicated' => true } if duplicate_request?(key_payload)
+
       body = {
         number: normalize_number(number),
         text: text
@@ -105,6 +109,10 @@ module Evolution
 
     def send_media(instance, number:, mediatype:, media:, mimetype:, caption: nil, file_name: nil, quoted: nil, delay: 0)
       # raise Error, "invalid media URL" unless media.is_a?(String) && media.start_with?("http")
+
+      # Deduplication check
+      key_payload = { instance: instance, number: number, media: media, mediatype: mediatype, caption: caption }
+      return { 'success' => true, 'deduplicated' => true } if duplicate_request?(key_payload)
 
       body = {
         number: normalize_number(number),
@@ -123,6 +131,10 @@ module Evolution
     end
 
     def send_whatsapp_audio(instance, number:, audio:, quoted: nil, delay: 0)
+      # Deduplication check
+      key_payload = { instance: instance, number: number, audio: audio }
+      return { 'success' => true, 'deduplicated' => true } if duplicate_request?(key_payload)
+
       body = {
         number: normalize_number(number),
         audio: audio
@@ -267,6 +279,13 @@ module Evolution
       return s unless s.end_with?('@s.whatsapp.net')
 
       s.split('@').first
+    end
+
+    def duplicate_request?(payload)
+      hash = Digest::MD5.hexdigest(payload.to_json)
+      key = "evolution:client:dedup:#{hash}"
+      # Expire in 3 minutes as requested
+      !Redis::Alfred.set(key, 1, nx: true, ex: 3.minutes)
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
-  Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
+  Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'].to_s.chomp('/') }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
O que foi corrigido:
Deduplicação de Mensagens (Vindo do Evolution):
No 
EvolutionController
, adicionei uma verificação usando Redis (TTL de 3 min) para o ID da mensagem. Isso evita que, se o mesmo WhatsApp estiver em duas instâncias, a mensagem seja processada duas vezes.
Deduplicação de Envio (Saindo para o Evolution):
No Evolution::Client, adicionei a mesma lógica para 
send_text
, 
send_media
 e send_audio. Se o sistema tentar enviar exatamente a mesma coisa para o mesmo número em menos de 3 minutos, ele bloqueia o segundo envio.
Correção das Imagens/Mídias:
URL Options: Configurei o ActiveStorage::Current.url_options dentro do Job do Evolution. Sem isso, o Rails não conseguia gerar links para os arquivos baixados em background, o que causava o erro de "link inválido" ou a imagem não aparecer.
Double Slash: Removi a barra final automática da FRONTEND_URL nas configurações, pois isso estava gerando links com barra dupla (ex: site.com//rails/...), o que também quebrava a exibição.